### PR TITLE
Added support for partial container rendering

### DIFF
--- a/src/ui/container.d
+++ b/src/ui/container.d
@@ -83,8 +83,10 @@ class Container : Component {
 
       child.layer = cast(ptrdiff_t)layer;
       child.parentWindow = parentWindow;
+      child.parentContainer = this;
       parentWindow._windowComponents[child.id] = child;
 
+      child.renderSub();
       child.show();
     });
   }
@@ -125,6 +127,7 @@ class Container : Component {
       child.layer = -1;
       child.parentWindow._windowComponents.remove(child.id);
       child.parentWindow = null;
+      child.parentContainer = null;
     });
   }
 

--- a/src/ui/graphics.d
+++ b/src/ui/graphics.d
@@ -8,6 +8,48 @@ import poison.core : Size, Point;
 import poison.ui.picture;
 import poison.ui.fonts;
 
+/// Original space struct for graphical elements.
+private struct OriginalSpace(TPosition,TSize) {
+  /// The original x position.
+  TPosition x;
+
+  /// The original y position.
+  TPosition y;
+
+  /// The original width.
+  TSize width;
+
+  /// The original height.
+  TSize height;
+}
+
+/// A sub rect of overflow calculation results.
+private struct SubRect {
+  /// The x coordinate.
+  float x;
+
+  /// The y coordinate.
+  float y;
+
+  /// The width.
+  float width;
+
+  /// The height.
+  float height;
+
+  /// The overflow top.
+  float overflowTop;
+
+  /// The overflow right.
+  float overflowRight;
+
+  /// The overflow bottom.
+  float overflowBottom;
+
+  /// The overflow left.
+  float overflowLeft;
+}
+
 /// Graphics wrapper for components.
 class Graphics {
   private:
@@ -20,8 +62,14 @@ class Graphics {
   /// The low-level background rectangle.
   RectangleShape _backgroundRect;
 
+  /// The original background rectangle's space.
+  OriginalSpace!(float,float) _originalBackgroundRect;
+
   /// The background picture.
   Picture _backgroundPicture;
+
+  /// The original background ´picture's space.
+  OriginalSpace!(ptrdiff_t,int) _originalBackgroundPicture;
 
   /// The size.
   Size _size;
@@ -35,6 +83,12 @@ class Graphics {
   /// The font size.
   uint _fontSize;
 
+  /// Boolean determining whether the background rectangle is displayable or not.
+  bool _displayableBackgroundRect;
+
+  /// Boolean determining whether the background picture is displayable or not.
+  bool _displayableBackgroundPicture;
+
   public:
   final:
   /// Creates a new graphics wrapper.
@@ -46,6 +100,10 @@ class Graphics {
     _position = new Point(0,0);
 
     _fontSize = 13;
+    _displayableBackgroundRect = true;
+    _displayableBackgroundPicture = true;
+    _originalBackgroundRect = OriginalSpace!(float,float)(0,0,0,0);
+    _originalBackgroundPicture = OriginalSpace!(ptrdiff_t, int)(0,0,0,0);
   }
 
   @property {
@@ -78,6 +136,16 @@ class Graphics {
     /// Sets the background picture.
     void backgroundPicture(Picture newBackgroundPicture) {
       _backgroundPicture = newBackgroundPicture;
+
+      if (_backgroundPicture) {
+        _backgroundPicture.position = _position;
+
+        _originalBackgroundPicture.x = _position.x;
+        _originalBackgroundPicture.y = _position.y;
+
+        _originalBackgroundPicture.width = _size.width;
+        _originalBackgroundPicture.height = _size.height;
+      }
     }
 
     /// Gets the font.
@@ -105,10 +173,14 @@ class Graphics {
 
       if (_backgroundRect) {
         _backgroundRect.position = Vector2f(cast(float)_position.x, cast(float)_position.y);
+        _originalBackgroundRect.x = _backgroundRect.position.x;
+        _originalBackgroundRect.y = _backgroundRect.position.y;
       }
 
       if (_backgroundPicture) {
         _backgroundPicture.position = _position;
+        _originalBackgroundPicture.x = cast(int)_position.x;
+        _originalBackgroundPicture.y = cast(int)_position.y;
       }
     }
   }
@@ -120,5 +192,104 @@ class Graphics {
     _backgroundRect = new RectangleShape(Vector2f(cast(float)_size.width, cast(float)_size.height));
     backgroundPaint = _backgroundPaint;
     position = _position;
+
+    _originalBackgroundRect.width = _backgroundRect.size.x;
+    _originalBackgroundRect.height = _backgroundRect.size.y;
+
+    _originalBackgroundPicture.width = cast(int)_size.width;
+    _originalBackgroundPicture.height = cast(int)_size.height;
+  }
+
+  package(poison):
+  @property {
+    /// Gets a boolean determining whether the background rectangle is displayable.
+    bool displayableBackgroundRect() { return _displayableBackgroundRect; }
+
+    /// Gets a boolean determining whether the background picture is displayable.
+    bool displayableBackgroundPicture() { return _displayableBackgroundPicture; }
+  }
+
+  /**
+  * Renders the sub rectangles for the graphics elements.
+  * Params:
+  *   position =  The position to be relative to.
+  *   size =      The size to be relative to.
+  */
+  void renderSub(Point position, Size size) {
+    import dsfml.graphics : IntRect;
+    import dsfml.system : Vector2f;
+
+    SubRect calculateOverflow(float targetX, float targetY, float targetWidth, float targetHeight) {
+      import std.math : fmax;
+
+      float overflowTop = fmax(0, (cast(float)position.y - targetY));
+      float overflowRight = fmax(0, (targetX + targetWidth) - (cast(float)position.x + cast(float)size.width));
+      float overflowBottom = fmax(0, (targetY + targetHeight) - (cast(float)position.y + cast(float)size.height));
+      float overflowLeft = fmax(0, (cast(float)position.x - targetX));
+
+      targetY += overflowTop;
+      targetHeight -= overflowTop;
+      targetWidth -= overflowRight;
+      targetHeight -= overflowBottom;
+      targetX += overflowLeft;
+      targetWidth -= overflowLeft;
+
+      return SubRect(targetX, targetY, targetWidth, targetHeight, overflowTop, overflowRight, overflowBottom, overflowLeft);
+    }
+
+    bool intersect(float width, float height, float x, float y) {
+      return(x < cast(float)position.x + cast(float)size.width) &&
+        (cast(float)position.x < (x + width)) &&
+        (y < cast(float)position.y + cast(float)size.height) &&
+        (cast(float)position.y < y + height);
+     }
+
+    if (_backgroundRect) {
+      _backgroundRect.size = Vector2f(_originalBackgroundRect.width, _originalBackgroundRect.height);
+      _backgroundRect.position = Vector2f(_originalBackgroundRect.x, _originalBackgroundRect.y);
+
+      auto rectSize = _backgroundRect.size;
+      auto rectPosition = _backgroundRect.position;
+
+      _displayableBackgroundRect = intersect(rectSize.x, rectSize.y, rectPosition.x, rectPosition.y);
+
+      if (_displayableBackgroundRect) {
+        auto overflow = calculateOverflow(rectPosition.x, rectPosition.y, rectSize.x, rectSize.y);
+
+        _backgroundRect.size = Vector2f(overflow.width, overflow.height);
+        _backgroundRect.position = Vector2f(overflow.x, overflow.y);
+      }
+    }
+
+    if (_backgroundPicture) {
+      _displayableBackgroundPicture = intersect(cast(float)_originalBackgroundPicture.x, cast(float)_originalBackgroundPicture.y, cast(float)_originalBackgroundPicture.width, cast(float)_originalBackgroundPicture.height);
+
+      if (_displayableBackgroundPicture) {
+        auto backgroundSprite = _backgroundPicture.backgroundSprite;
+        auto drawingSprite = _backgroundPicture.drawingSprite;
+
+        if (backgroundSprite) {
+          backgroundSprite.position = new Point(_originalBackgroundPicture.x, _originalBackgroundPicture.y);
+          backgroundSprite.textureRect = IntRect(0, 0, cast(int)_originalBackgroundPicture.width, cast(int)_originalBackgroundPicture.height);
+        }
+
+        if (drawingSprite) {
+          drawingSprite.position = new Point(_originalBackgroundPicture.x, _originalBackgroundPicture.y);
+          drawingSprite.textureRect = IntRect(0, 0, cast(int)_originalBackgroundPicture.width, cast(int)_originalBackgroundPicture.height);
+        }
+
+        auto overflow = calculateOverflow(cast(float)_originalBackgroundPicture.x, cast(float)_originalBackgroundPicture.y, cast(float)_originalBackgroundPicture.width, cast(float)_originalBackgroundPicture.height);
+
+        if (backgroundSprite) {
+          backgroundSprite.textureRect = IntRect(cast(int)overflow.overflowLeft, cast(int)overflow.overflowTop, cast(int)overflow.width, cast(int)overflow.height);
+          backgroundSprite.position = new Point(cast(ptrdiff_t)overflow.x, cast(ptrdiff_t)overflow.y);
+        }
+
+        if (drawingSprite) {
+          drawingSprite.textureRect = IntRect(cast(int)overflow.overflowLeft, cast(int)overflow.overflowTop, cast(int)overflow.width, cast(int)overflow.height);
+          drawingSprite.position = new Point(cast(ptrdiff_t)overflow.x, cast(ptrdiff_t)overflow.y);
+        }
+      }
+    }
   }
 }

--- a/src/ui/window.d
+++ b/src/ui/window.d
@@ -111,8 +111,6 @@ class Window : Container {
   /// Shows the window.
   override void show() {
     if (!_window) {
-      import std.stdio;
-      writefln("title: '%s'", title);
       _window = new RenderWindow(_videoMode, title, (WindowStyle.Titlebar | WindowStyle.Resize | WindowStyle.Close), _context);
 
       if (_fps) {


### PR DESCRIPTION
Added support for partial conainer rendering calculating overflow
offsets of child components and only rendering relevant graphics of
them. The algorithm and implementation still needs to be optimized and
has only been written to work as of now.